### PR TITLE
ci: set build metadata in version

### DIFF
--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -19,14 +19,14 @@ jobs:
             src: .
             os: public.ecr.aws/firecracker/fcuvm:v77
             flags: ""
-            cmd: ./Hydrunfile rust x86_64
+            cmd: ./Hydrunfile rust x86_64 loopholelabs
             dst: out/*
             runner: depot-ubuntu-22.04-32
           - id: rust.aarch64
             src: .
             os: public.ecr.aws/firecracker/fcuvm:v77
             flags: ""
-            cmd: ./Hydrunfile rust aarch64
+            cmd: ./Hydrunfile rust aarch64 loopholelabs
             dst: out/*
             runner: depot-ubuntu-22.04-arm-32
 
@@ -113,5 +113,9 @@ jobs:
             echo "Skipping S3 upload: unsupported ref type $GITHUB_REF"
             exit 0
           fi
+          echo "Uploading artifacts to: ${{ vars.S3_BUCKET_URL }}firecracker/${UPLOAD_FOLDER}/"
+          aws s3 cp /tmp/out ${{ vars.S3_BUCKET_URL }}firecracker/${UPLOAD_FOLDER}/ --recursive
+
+          UPLOAD_FOLDER="dev/sha/${GITHUB_SHA}"
           echo "Uploading artifacts to: ${{ vars.S3_BUCKET_URL }}firecracker/${UPLOAD_FOLDER}/"
           aws s3 cp /tmp/out ${{ vars.S3_BUCKET_URL }}firecracker/${UPLOAD_FOLDER}/ --recursive

--- a/Hydrunfile
+++ b/Hydrunfile
@@ -7,6 +7,11 @@ if [ "$1" = "rust" ]; then
     # Configure Git
     git config --global --add safe.directory '*'
 
+    # Set build metadata in version
+    current_version=$(cat src/firecracker/Cargo.toml | grep '^version =' | cut -d'"' -f 2)
+    git_sha=$(git rev-parse HEAD | head -c 12)
+    ./tools/bump-version.sh "$current_version+$3.$git_sha"
+
     # Build
     export RUSTFLAGS='-C target-feature=+crt-static'
     cargo build --package firecracker --package jailer --package seccompiler --package rebase-snap --package cpu-template-helper --target "$2-unknown-linux-musl" --all-features --release


### PR DESCRIPTION
Add build metadata to the binary version to help identify which binary is actually being used.

An example of how a `--version` output looks like:
```
$ firecracker --version
Firecracker v1.12.0-dev+loopholelabs.eec5b840de1c

2025-04-08T20:30:48.450684833 [anonymous-instance:main] Firecracker exiting successfully. exit_code=0
```

Also upload individual commit builds to S3 to keep a history of builds.