### PR TITLE
feat: making vsock event loop pauseable

### DIFF
--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -366,7 +366,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         .downcast_mut::<Vsock<VsockUnixBackend>>()
                         .unwrap();
 
-                    let pause = vsock.pause().expect("failed to acquire vsock pause mutex");
+                    let pause = vsock.pause.lock().expect("failed to acquire vsock pause mutex");
 
                     // Send Transport event to reset connections if device
                     // is activated.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -366,7 +366,8 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         .downcast_mut::<Vsock<VsockUnixBackend>>()
                         .unwrap();
 
-                    let pause = vsock.pause.lock().expect("failed to acquire vsock pause mutex");
+                    let pause = vsock.pause.clone();
+                    let guard = pause.lock().expect("failed to acquire vsock pause mutex");
 
                     // Send Transport event to reset connections if device
                     // is activated.
@@ -390,7 +391,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         device_info: device_info.clone(),
                     });
 
-                    drop(pause);
+                    drop(guard);
                 }
                 TYPE_RNG => {
                     let entropy = locked_device

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -366,6 +366,8 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         .downcast_mut::<Vsock<VsockUnixBackend>>()
                         .unwrap();
 
+                    let pause = vsock.pause().expect("failed to acquire vsock pause mutex");
+
                     // Send Transport event to reset connections if device
                     // is activated.
                     if vsock.is_activated() {
@@ -387,6 +389,8 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                         transport_state,
                         device_info: device_info.clone(),
                     });
+
+                    drop(pause);
                 }
                 TYPE_RNG => {
                     let entropy = locked_device

--- a/src/vmm/src/devices/virtio/vsock/device.rs
+++ b/src/vmm/src/devices/virtio/vsock/device.rs
@@ -137,7 +137,7 @@ where
         &self.backend
     }
 
-    pub fn pause(&self) -> LockResult<MutexGuard<'_, ()>> {
+    pub fn pause(&mut self) -> LockResult<MutexGuard<'_, ()>> {
         self.pause.lock()
     }
 

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -182,6 +182,7 @@ where
         let evset = event.event_set();
 
         if self.is_activated() {
+            let pause = self.pause().expect("failed to acquire vsock pause mutex");
             let mut raise_irq = false;
             match source {
                 Self::PROCESS_ACTIVATE => self.handle_activate_event(ops),
@@ -194,6 +195,7 @@ where
             if raise_irq {
                 self.signal_used_queue().unwrap_or_default();
             }
+            drop(pause);
         } else {
             warn!(
                 "Vsock: The device is not yet activated. Spurious event received: {:?}",

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -182,7 +182,7 @@ where
         let evset = event.event_set();
 
         if self.is_activated() {
-            let pause = self.pause().expect("failed to acquire vsock pause mutex");
+            let pause = self.pause.lock().expect("failed to acquire vsock pause mutex");
             let mut raise_irq = false;
             match source {
                 Self::PROCESS_ACTIVATE => self.handle_activate_event(ops),

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -182,7 +182,8 @@ where
         let evset = event.event_set();
 
         if self.is_activated() {
-            let pause = self.pause.lock().expect("failed to acquire vsock pause mutex");
+            let pause = &self.pause;
+            let guard = pause.lock().expect("failed to acquire vsock pause mutex");
             let mut raise_irq = false;
             match source {
                 Self::PROCESS_ACTIVATE => self.handle_activate_event(ops),
@@ -195,7 +196,7 @@ where
             if raise_irq {
                 self.signal_used_queue().unwrap_or_default();
             }
-            drop(pause);
+            drop(guard);
         } else {
             warn!(
                 "Vsock: The device is not yet activated. Spurious event received: {:?}",

--- a/src/vmm/src/devices/virtio/vsock/event_handler.rs
+++ b/src/vmm/src/devices/virtio/vsock/event_handler.rs
@@ -182,7 +182,7 @@ where
         let evset = event.event_set();
 
         if self.is_activated() {
-            let pause = &self.pause;
+            let pause = self.pause.clone();
             let guard = pause.lock().expect("failed to acquire vsock pause mutex");
             let mut raise_irq = false;
             match source {


### PR DESCRIPTION
This PR adds a simple mutex to the vsock device which allows an external caller to pause the vsock's processing loop. 

This functionality is then used during snapshotting to make sure the vsock device is no longer being modified when its state is snapshotted. 